### PR TITLE
Fix formatDate options in selectDate

### DIFF
--- a/jquery.calendrical.js
+++ b/jquery.calendrical.js
@@ -385,8 +385,7 @@
                                             endDate.getTime() -
                                             selected.getTime()
                                         ),
-                                        options.usa,
-                                        options.separator
+                                        options
                                     ));
                                 }
                             }


### PR DESCRIPTION
The call to determine the new endDate was passing options.usa, options.separator to formatDate causing endDate to be set to NaN. It now just passes the options collection as formatDate expects.